### PR TITLE
Update modinfo.json - icon link correction

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -9,7 +9,7 @@
   "date": "2024-11-08",
   "signature": " ",
   "forum": "https://github.com/gb6162166/gb6-definitive/discussions",
-  "icon": "https://raw.githubusercontent.com/gb6162166/gb6-definitive/refs/heads/main/gb6-definitive-icon.png",
+  "icon": "https://raw.githubusercontent.com/gb6162166/gb6-definitive/main/gb6-definitive-icon.png",
   "category": [
 	  "maps",
 	  "titans"


### PR DESCRIPTION
The link to your icon was not working, here's a fix (I hope). Might need to update 'version' and 'date', too.
o7, kasa 